### PR TITLE
Add samples, README and extra tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Your Name
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE.meta
+++ b/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6d63e73c6493b408b9a9c1bd14678c69
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Unity Notion Downloader
+
+This Unity package provides a simple way to download and cache content from Notion databases. It includes a downloader with basic caching utilities and helper classes for reading values from the Notion API.
+
+## Features
+- Download Notion database tables or pages from the Unity Editor
+- Cache previously downloaded results for faster iteration
+- Utilities for parsing and converting Notion data types
+- Unit tests for the main classes
+
+## Samples
+A few simple usage samples are included under the `Samples~/` folder once the package is installed.
+
+## Installation
+Add this repository as a Git package to your Unity project:
+```
+https://github.com/your-org/UnityNotionDownloader.git
+```
+
+## Tests
+Editor tests are located in the `Tests/Editor` folder. They use NUnit and can be run from the Unity Test Runner.

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a0147d54bc0344f439c9c8680ee6eaf0
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/BasicUsage/DownloadDatabaseSample.cs
+++ b/Samples~/BasicUsage/DownloadDatabaseSample.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+using Game.Serialization;
+using Game.Serialization.Notion;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using UniRx;
+
+public class DownloadDatabaseSample : MonoBehaviour
+{
+    public string apiKey;
+    public string notionVersion = "2022-06-28";
+    public string databaseId;
+
+    void Start()
+    {
+        var cache = new DatabaseCache();
+        var downloader = new NotionDownloader(cache, apiKey, notionVersion);
+        downloader
+            .DownloadDatabaseToListObservable<Dictionary<string, object>>(databaseId, jo => jo.ToObject<Dictionary<string, object>>(), true)
+            .Subscribe(list => Debug.Log($"Downloaded {list.Count} rows"));
+    }
+}

--- a/Samples~/BasicUsage/README.txt
+++ b/Samples~/BasicUsage/README.txt
@@ -1,0 +1,4 @@
+This example shows how to download a Notion database at runtime.
+Attach `DownloadDatabaseSample` to a GameObject and provide your Notion API key,
+database ID and version. When the scene runs, the script downloads the table and
+logs the number of rows.

--- a/Tests/Editor/DatabaseCacheExtraTests.cs
+++ b/Tests/Editor/DatabaseCacheExtraTests.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using System.Collections.Generic;
+using Game.Serialization;
+
+public class DatabaseCacheExtraTests
+{
+    [Test]
+    public void ContainsDatabase_ReturnsCorrectValue()
+    {
+        var cache = new DatabaseCache();
+        cache.SetTableFromCache<string>("db", new List<object>{"a"});
+        Assert.IsTrue(cache.ContainsDatabase("db"));
+        Assert.IsFalse(cache.ContainsDatabase("missing"));
+    }
+
+    [Test]
+    public void GetItemsFromCache_FiltersItems()
+    {
+        var cache = new DatabaseCache();
+        var list = new List<object>{ "one", "two", "three" };
+        cache.SetTableFromCache<string>("db", list);
+        var result = cache.GetItemsFromCache<string>(s => s.Contains("o"));
+        CollectionAssert.AreEqual(new List<string>{"one","two"}, result);
+    }
+}

--- a/Tests/Editor/DatabaseCacheExtraTests.cs.meta
+++ b/Tests/Editor/DatabaseCacheExtraTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 58115cbd4983f44d682b2d5cd9cb9558
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add a basic MIT license
- document how to use the package in README
- provide a simple runtime sample script
- add tests covering additional cache behaviour

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ebd789e28832ebfd8eac8c373acd5